### PR TITLE
Fix GitHub repository URL to the correct version.

### DIFF
--- a/adafruit_nunchuk.py
+++ b/adafruit_nunchuk.py
@@ -46,7 +46,7 @@ import time
 from adafruit_bus_device.i2c_device import I2CDevice
 
 __version__ = "0.0.0-auto.0"
-__repo__ = "https://github.com/caternuson/CircuitPython_Nunchuk.git"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Nunchuk.git"
 
 _DEFAULT_ADDRESS = 0x52
 _I2C_INIT_DELAY = 0.1


### PR DESCRIPTION
What the title says. This change is needed so the upcoming `circup` utility can work properly with this module (see https://github.com/ntoll/circup).

Just ask if you've any questions..!  Thank you!

cc/@ladyada