### PR TITLE
Use the new parameter for USB HID

### DIFF
--- a/examples/nunchuk_accel_mouse.py
+++ b/examples/nunchuk_accel_mouse.py
@@ -2,10 +2,11 @@
 # SPDX-License-Identifier: MIT
 
 import board
+import usb_hid
 from adafruit_hid.mouse import Mouse
 import adafruit_nunchuk
 
-m = Mouse()
+m = Mouse(usb_hid.devices)
 nc = adafruit_nunchuk.Nunchuk(board.I2C())
 
 centerX = 120

--- a/examples/nunchuk_analog_mouse.py
+++ b/examples/nunchuk_analog_mouse.py
@@ -2,10 +2,11 @@
 # SPDX-License-Identifier: MIT
 
 import board
+import usb_hid
 from adafruit_hid.mouse import Mouse
 import adafruit_nunchuk
 
-m = Mouse()
+m = Mouse(usb_hid.devices)
 nc = adafruit_nunchuk.Nunchuk(board.I2C())
 
 centerX = 128

--- a/examples/nunchuk_mouse.py
+++ b/examples/nunchuk_mouse.py
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: MIT
 
 import board
+import usb_hid
 from adafruit_hid.mouse import Mouse
 import adafruit_nunchuk
 
 THRESHOLD = 10
 
-m = Mouse()
+m = Mouse(usb_hid.devices)
 nc = adafruit_nunchuk.Nunchuk(board.I2C())
 
 while True:


### PR DESCRIPTION
There might be other Adafruit repository that use:
`Mouse()
`

And it should be replaced by
`Mouse(usb_hid.devices)
`
with one addtional import:
`import usb_hid
`
