### PR TITLE
Convert to a package and add support for the Classic Controller

### DIFF
--- a/adafruit_nunchuk/__init__.py
+++ b/adafruit_nunchuk/__init__.py
@@ -36,8 +36,8 @@ _I2C_BUFFER_UPDATE_DELAY = 0.05
 
 class NunchukBase:
     """Base Class which provides interface to Nintendo Nunchuk style controllers.
-        :param i2c: An i2c device.
-        :address: an i2c address. Defaults to _DEFAULT_ADDRESS (0x52).
+    :param i2c: An i2c device.
+    :address: an i2c address. Defaults to _DEFAULT_ADDRESS (0x52).
     """
 
     def __init__(self, i2c, address=_DEFAULT_ADDRESS):

--- a/adafruit_nunchuk/__init__.py
+++ b/adafruit_nunchuk/__init__.py
@@ -6,7 +6,7 @@
 ================================================================================
 Base Library for the Nintento Nunchuck Extension Controller libraries.
 
-* Author(s): John Furcean 
+* Author(s): John Furcean
 
 Implementation Notes
 --------------------
@@ -31,7 +31,8 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_PortalBase.git"
 _DEFAULT_ADDRESS = 0x52
 _I2C_INIT_DELAY = 0.1
 _I2C_READ_DELAY = 0.01
-_I2C_BUFFER_UPDATE_DELAY = .05
+_I2C_BUFFER_UPDATE_DELAY = 0.05
+
 
 class NunchukBase:
     """Base Class which provides interface to Nintendo Nunchuk style controllers.
@@ -52,8 +53,8 @@ class NunchukBase:
             i2c_dev.write(b"\xFB\x00")
         self.last_updated = time.monotonic()
 
-    
-    def _read_data(self):
+    def read_data(self):
+        """Reads data stream from register"""
         if (time.monotonic() - self.last_updated) > _I2C_BUFFER_UPDATE_DELAY:
             self.last_updated = time.monotonic()
             self._read_register(b"\x00")

--- a/adafruit_nunchuk/__init__.py
+++ b/adafruit_nunchuk/__init__.py
@@ -50,7 +50,9 @@ class NunchukBase:
             i2c_dev.write(b"\xF0\x55")
             time.sleep(_I2C_INIT_DELAY)
             i2c_dev.write(b"\xFB\x00")
-        self.last_updated = time.monotonic()
+            time.sleep(_I2C_INIT_DELAY)
+
+        self.last_updated = 0
 
     def read_data(self):
         """Reads data stream from register"""

--- a/adafruit_nunchuk/__init__.py
+++ b/adafruit_nunchuk/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021 John Furcean
+# SPDX-FileCopyrightText: 2019 Carter Nelson for Adafruit Industries
 #
 # SPDX-License-Identifier: MIT
 """
@@ -6,7 +6,7 @@
 ================================================================================
 Base Library for the Nintento Nunchuck Extension Controller libraries.
 
-* Author(s): John Furcean
+* Author(s): Carter Nelson, John Furcean
 
 Implementation Notes
 --------------------

--- a/adafruit_nunchuk/__init__.py
+++ b/adafruit_nunchuk/__init__.py
@@ -36,9 +36,8 @@ _I2C_BUFFER_UPDATE_DELAY = 0.05
 
 class NunchukBase:
     """Base Class which provides interface to Nintendo Nunchuk style controllers.
-    :param i2c: An i2c device.
-    :address: an i2c address.
-                    Defaults to _DEFAULT_ADDRESS (0x52).
+        :param i2c: An i2c device.
+        :address: an i2c address. Defaults to _DEFAULT_ADDRESS (0x52).
     """
 
     def __init__(self, i2c, address=_DEFAULT_ADDRESS):

--- a/adafruit_nunchuk/__init__.py
+++ b/adafruit_nunchuk/__init__.py
@@ -1,7 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2021 John Furcean
+#
+# SPDX-License-Identifier: MIT
 """
 `adafruit_nunchuk`
 ================================================================================
-Base Library for the Nunchuck Style libraries.
+Base Library for the Nintento Nunchuck Extension Controller libraries.
+
 * Author(s): John Furcean 
 
 Implementation Notes
@@ -28,7 +32,6 @@ _DEFAULT_ADDRESS = 0x52
 _I2C_INIT_DELAY = 0.1
 _I2C_READ_DELAY = 0.01
 _I2C_BUFFER_UPDATE_DELAY = .05
-
 
 class NunchukBase:
     """Base Class which provides interface to Nintendo Nunchuk style controllers.

--- a/adafruit_nunchuk/classic_controller.py
+++ b/adafruit_nunchuk/classic_controller.py
@@ -19,10 +19,7 @@ Implementation Notes
 
 * Adafruit CircuitPython firmware for the supported boards:
   https://github.com/adafruit/circuitpython/releases
-* Adafruit's Bus Device library: https://github.com/adafruit/Adafruit_CircuitPython_BusDevice
 """
-import time
-from adafruit_bus_device.i2c_device import I2CDevice
 from adafruit_nunchuk import NunchukBase
 
 
@@ -37,11 +34,10 @@ class ClassicController(NunchukBase):
     def __init__(self, i2c, address=_DEFAULT_ADDRESS):
         super().__init__(i2c, address=address)
 
-
     @property
     def joystick_right(self):
         """Return tuple of current right joystick position."""
-        self._read_data()
+        self.read_data()
         x = (self.buffer[0] & 0xC0) >> 3
         x |= (self.buffer[1] & 0xC0) >> 5
         x |= (self.buffer[2] & 0x80) >> 7
@@ -51,95 +47,95 @@ class ClassicController(NunchukBase):
     @property
     def joystick_left(self):
         """Return tuple of current left joystick position."""
-        self._read_data()
+        self.read_data()
         return (self.buffer[0] & 0x3F, self.buffer[1] & 0x3F)
 
     @property
     def trigger_right(self):
         """Return reading right trigger position"""
-        self._read_data()
+        self.read_data()
         return self.buffer[3] & 0x1F
 
     @property
     def trigger_left(self):
         """Return reading left trigger position"""
-        self._read_data()
+        self.read_data()
         return ((self.buffer[2] & 0x60) >> 2) | ((self.buffer[3] & 0xE0) >> 5)
 
     @property
     def dpad_left(self):
         """Return current pressed state of D-pad left."""
-        self._read_data()
+        self.read_data()
         return not bool(self.buffer[5] & 0x2)
 
     @property
     def dpad_right(self):
         """Return current pressed state of D-pad right"""
-        self._read_data()
+        self.read_data()
         return not bool(self.buffer[4] & 0x80)
 
     @property
     def dpad_up(self):
         """Return current pressed state of D-pad up."""
-        self._read_data()
+        self.read_data()
         return not bool(self.buffer[5] & 0x1)
 
     @property
     def dpad_down(self):
         """Return current pressed state of D-pad down"""
-        self._read_data()
+        self.read_data()
         return not bool(self.buffer[4] & 0x40)
 
     @property
     def button_a(self):
         """Return current pressed state of the A button"""
-        self._read_data()
+        self.read_data()
         return not bool(self.buffer[5] & 0x10)
 
     @property
     def button_b(self):
         """Return current pressed state of the B button"""
-        self._read_data()
+        self.read_data()
         return not bool(self.buffer[5] & 0x40)
 
     @property
     def button_x(self):
         """Return current pressed state of the X button"""
-        self._read_data()
+        self.read_data()
         return not bool(self.buffer[5] & 0x8)
 
     @property
     def button_y(self):
         """Return current pressed state of the Y button"""
-        self._read_data()
+        self.read_data()
         return not bool(self.buffer[5] & 0x20)
 
     @property
     def button_zr(self):
         """Return current pressed state of the Zr button"""
-        self._read_data()
+        self.read_data()
         return not bool(self.buffer[5] & 0x4)
 
     @property
     def button_zl(self):
         """Return current pressed state of the Zl button"""
-        self._read_data()
+        self.read_data()
         return not bool(self.buffer[5] & 0x80)
 
     @property
     def button_home(self):
         """Return current pressed state of the Home button"""
-        self._read_data()
+        self.read_data()
         return not bool(self.buffer[4] & 0x8)
 
     @property
     def button_start(self):
         """Return current pressed state of the Start/Plus button"""
-        self._read_data()
+        self.read_data()
         return not bool(self.buffer[4] & 0x4)
 
     @property
     def button_select(self):
         """Return current pressed state of the Select/Minus button"""
-        self._read_data()
+        self.read_data()
         return not bool(self.buffer[4] & 0x10)

--- a/adafruit_nunchuk/classic_controller.py
+++ b/adafruit_nunchuk/classic_controller.py
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: Copyright (c) 2021 John Furcean
+#
+# SPDX-License-Identifier: MIT
+"""
+`adafruit_nunchuk.classic_controller`
+================================================================================
+CircuitPython library for the Nintendo Wii Classic Controller
+
+* Author(s): John Furcean
+
+Implementation Notes
+--------------------
+
+**Hardware:**
+
+* Wii Classic Controller http://wiibrew.org/wiki/Wiimote/Extension_Controllers/Classic_Controller
+
+**Software and Dependencies:**
+
+* Adafruit CircuitPython firmware for the supported boards:
+  https://github.com/adafruit/circuitpython/releases
+* Adafruit's Bus Device library: https://github.com/adafruit/Adafruit_CircuitPython_BusDevice
+"""
+import time
+from adafruit_bus_device.i2c_device import I2CDevice
+from adafruit_nunchuk import NunchukBase
+
+
+_DEFAULT_ADDRESS = 0x52
+_I2C_INIT_DELAY = 0.1
+_I2C_READ_DELAY = 0.01
+
+
+class ClassicController(NunchukBase):
+    """Class which provides interface to the Nintendo Classic controller."""
+
+    def __init__(self, i2c, address=_DEFAULT_ADDRESS):
+        super().__init__(i2c, address=address)
+
+
+    @property
+    def joystick_right(self):
+        """Return tuple of current right joystick position."""
+        self._read_data()
+        x = (self.buffer[0] & 0xC0) >> 3
+        x |= (self.buffer[1] & 0xC0) >> 5
+        x |= (self.buffer[2] & 0x80) >> 7
+
+        return (x, self.buffer[2] & 0x1F)
+
+    @property
+    def joystick_left(self):
+        """Return tuple of current left joystick position."""
+        self._read_data()
+        return (self.buffer[0] & 0x3F, self.buffer[1] & 0x3F)
+
+    @property
+    def trigger_right(self):
+        """Return reading right trigger position"""
+        self._read_data()
+        return self.buffer[3] & 0x1F
+
+    @property
+    def trigger_left(self):
+        """Return reading left trigger position"""
+        self._read_data()
+        return ((self.buffer[2] & 0x60) >> 2) | ((self.buffer[3] & 0xE0) >> 5)
+
+    @property
+    def dpad_left(self):
+        """Return current pressed state of D-pad left."""
+        self._read_data()
+        return not bool(self.buffer[5] & 0x2)
+
+    @property
+    def dpad_right(self):
+        """Return current pressed state of D-pad right"""
+        self._read_data()
+        return not bool(self.buffer[4] & 0x80)
+
+    @property
+    def dpad_up(self):
+        """Return current pressed state of D-pad up."""
+        self._read_data()
+        return not bool(self.buffer[5] & 0x1)
+
+    @property
+    def dpad_down(self):
+        """Return current pressed state of D-pad down"""
+        self._read_data()
+        return not bool(self.buffer[4] & 0x40)
+
+    @property
+    def button_a(self):
+        """Return current pressed state of the A button"""
+        self._read_data()
+        return not bool(self.buffer[5] & 0x10)
+
+    @property
+    def button_b(self):
+        """Return current pressed state of the B button"""
+        self._read_data()
+        return not bool(self.buffer[5] & 0x40)
+
+    @property
+    def button_x(self):
+        """Return current pressed state of the X button"""
+        self._read_data()
+        return not bool(self.buffer[5] & 0x8)
+
+    @property
+    def button_y(self):
+        """Return current pressed state of the Y button"""
+        self._read_data()
+        return not bool(self.buffer[5] & 0x20)
+
+    @property
+    def button_zr(self):
+        """Return current pressed state of the Zr button"""
+        self._read_data()
+        return not bool(self.buffer[5] & 0x4)
+
+    @property
+    def button_zl(self):
+        """Return current pressed state of the Zl button"""
+        self._read_data()
+        return not bool(self.buffer[5] & 0x80)
+
+    @property
+    def button_home(self):
+        """Return current pressed state of the Home button"""
+        self._read_data()
+        return not bool(self.buffer[4] & 0x8)
+
+    @property
+    def button_start(self):
+        """Return current pressed state of the Start/Plus button"""
+        self._read_data()
+        return not bool(self.buffer[4] & 0x4)
+
+    @property
+    def button_select(self):
+        """Return current pressed state of the Select/Minus button"""
+        self._read_data()
+        return not bool(self.buffer[4] & 0x10)

--- a/adafruit_nunchuk/classic_controller.py
+++ b/adafruit_nunchuk/classic_controller.py
@@ -40,22 +40,21 @@ class ClassicController(NunchukBase):
 
         # https://wiibrew.org/wiki/Wiimote/Extension_Controllers/Classic_Controller
 
-        # right joystick
         jrx = (self.buffer[0] & 0xC0) >> 3
         jrx |= (self.buffer[1] & 0xC0) >> 5
         jrx |= (self.buffer[2] & 0x80) >> 7
         jry = self.buffer[2] & 0x1F
 
-        # right joystick
+        # left joystick
         jlx = self.buffer[0] & 0x3F
         jly = self.buffer[1] & 0x3F
 
-        # left trigger
-        tl = (self.buffer[2] & 0x60) >> 2  # pylint: disable=invalid-name
-        tl |= (self.buffer[3] & 0xE0) >> 5  # pylint: disable=invalid-name
+        # analog trigger - left
+        atl = (self.buffer[2] & 0x60) >> 2  # pylint: disable=invalid-name
+        atl |= (self.buffer[3] & 0xE0) >> 5  # pylint: disable=invalid-name
 
-        # right trigger
-        tr = self.buffer[3] & 0x1F  # pylint: disable=invalid-name
+        # analog trigger - right
+        atr = self.buffer[3] & 0x1F  # pylint: disable=invalid-name
 
         # D-Pad
         dl = not bool(self.buffer[5] & 0x2)  # pylint: disable=invalid-name
@@ -67,6 +66,8 @@ class ClassicController(NunchukBase):
         A = not bool(self.buffer[5] & 0x10)  # pylint: disable=invalid-name
         B = not bool(self.buffer[5] & 0x40)  # pylint: disable=invalid-name
         X = not bool(self.buffer[5] & 0x8)  # pylint: disable=invalid-name
+        btr = not bool(self.buffer[4] & 0x2)  # pylint: disable=invalid-name
+        btl = not bool(self.buffer[4] & 0x20)  # pylint: disable=invalid-name
         Y = not bool(self.buffer[5] & 0x20)  # pylint: disable=invalid-name
         ZL = not bool(self.buffer[5] & 0x80)  # pylint: disable=invalid-name
         ZR = not bool(self.buffer[5] & 0x4)  # pylint: disable=invalid-name
@@ -74,27 +75,8 @@ class ClassicController(NunchukBase):
         select = not bool(self.buffer[4] & 0x10)
         home = not bool(self.buffer[4] & 0x8)
 
-        return (
-            jrx,
-            jry,
-            jlx,
-            jly,
-            dl,
-            dr,
-            du,
-            dd,
-            A,
-            B,
-            X,
-            Y,
-            tr,
-            tl,
-            ZR,
-            ZL,
-            start,
-            select,
-            home,
-        )
+        return jrx, jry, jlx, jly, dl, dr, du, dd, A, B, X, Y, atr,\
+         atl, btr, btl, ZR, ZL, start, select, home
 
     @property
     def joystick_R(self):  # pylint: disable=invalid-name
@@ -148,40 +130,39 @@ class ClassicController(NunchukBase):
         return self.values[11]
 
     @property
-    def trigger_R(self):  # pylint: disable=invalid-name
-        """Return reading right trigger position"""
-        return self.values[12]
+    def button_RT(self):  # pylint: disable=invalid-name
+        """Return current pressed state of the right trigger button"""
+        return self.values[14]
 
     @property
-    def trigger_L(self):  # pylint: disable=invalid-name
-        """Return reading left trigger position"""
-        return self.values[13]
+    def button_LT(self):  # pylint: disable=invalid-name
+        """Return current pressed state of the left trigger button"""
+        return self.values[15]
 
     @property
     def button_ZR(self):  # pylint: disable=invalid-name
         """Return current pressed state of the Zr button"""
-        return self.values[14]
+        return self.values[16]
 
     @property
     def button_ZL(self):  # pylint: disable=invalid-name
         """Return current pressed state of the Zl button"""
-        return self.values[15]
+        return self.values[17]
 
     @property
     def button_start(self):
         """Return current pressed state of the Start button"""
-        return self.values[16]
+        return self.values[18]
 
     @property
     def button_select(self):
         """Return current pressed state of the Select button"""
-        self.read_data()
-        return self.values[17]
+        return self.values[19]
 
     @property
     def button_home(self):
         """Return current pressed state of the Home button"""
-        return self.values[18]
+        return self.values[20]
 
     @property
     def button_plus(self):

--- a/adafruit_nunchuk/classic_controller.py
+++ b/adafruit_nunchuk/classic_controller.py
@@ -40,15 +40,15 @@ class ClassicController(NunchukBase):
 
         # https://wiibrew.org/wiki/Wiimote/Extension_Controllers/Classic_Controller
 
-        # left joystick
-        jlx = (self.buffer[0] & 0xC0) >> 3
-        jlx |= (self.buffer[1] & 0xC0) >> 5
-        jlx |= (self.buffer[2] & 0x80) >> 7
-        jly = self.buffer[2] & 0x1F
+        # right joystick
+        jrx = (self.buffer[0] & 0xC0) >> 3
+        jrx |= (self.buffer[1] & 0xC0) >> 5
+        jrx |= (self.buffer[2] & 0x80) >> 7
+        jry = self.buffer[2] & 0x1F
 
         # right joystick
-        jrx = self.buffer[0] & 0x3F
-        jry = self.buffer[1] & 0x3F
+        jlx = self.buffer[0] & 0x3F
+        jly = self.buffer[1] & 0x3F
 
         # left trigger
         tl = (self.buffer[2] & 0x60) >> 2  # pylint: disable=invalid-name
@@ -75,10 +75,10 @@ class ClassicController(NunchukBase):
         home = not bool(self.buffer[4] & 0x8)
 
         return (
-            jlx,
-            jly,
             jrx,
             jry,
+            jlx,
+            jly,
             dl,
             dr,
             du,

--- a/adafruit_nunchuk/classic_controller.py
+++ b/adafruit_nunchuk/classic_controller.py
@@ -75,8 +75,29 @@ class ClassicController(NunchukBase):
         select = not bool(self.buffer[4] & 0x10)
         home = not bool(self.buffer[4] & 0x8)
 
-        return jrx, jry, jlx, jly, dl, dr, du, dd, A, B, X, Y, atr,\
-         atl, btr, btl, ZR, ZL, start, select, home
+        return (
+            jrx,
+            jry,
+            jlx,
+            jly,
+            dl,
+            dr,
+            du,
+            dd,
+            A,
+            B,
+            X,
+            Y,
+            atr,
+            atl,
+            btr,
+            btl,
+            ZR,
+            ZL,
+            start,
+            select,
+            home,
+        )
 
     @property
     def joystick_R(self):  # pylint: disable=invalid-name

--- a/adafruit_nunchuk/nunchuk.py
+++ b/adafruit_nunchuk/nunchuk.py
@@ -38,31 +38,46 @@ class Nunchuk(NunchukBase):
         super().__init__(i2c, address=address)
 
     @property
+    def values(self):
+        """Return tuple of values."""
+        self.read_data()
+
+        # https://wiibrew.org/wiki/Wiimote/Extension_Controllers/Nunchuck
+
+        # joystick
+        jx = self.buffer[0]  # pylint: disable=invalid-name
+        jy = self.buffer[1]  # pylint: disable=invalid-name
+
+        # buttons
+        C = not bool(self.buffer[5] & 0x02)  # pylint: disable=invalid-name
+        Z = not bool(self.buffer[5] & 0x01)  # pylint: disable=invalid-name
+
+        # acceleration
+        ax = (self.buffer[5] & 0xC0) >> 6  # pylint: disable=invalid-name
+        ax |= self.buffer[2] << 2  # pylint: disable=invalid-name
+        ay = (self.buffer[5] & 0x30) >> 4  # pylint: disable=invalid-name
+        ay |= self.buffer[3] << 2  # pylint: disable=invalid-name
+        az = (self.buffer[5] & 0x0C) >> 2  # pylint: disable=invalid-name
+        az |= self.buffer[4] << 2  # pylint: disable=invalid-name
+
+        return jx, jy, C, Z, ax, ay, az
+
+    @property
     def joystick(self):
         """Return tuple of current joystick position."""
-        self.read_data()
-        return self.buffer[0], self.buffer[1]
+        return self.values[0], self.values[1]
 
     @property
     def button_C(self):  # pylint: disable=invalid-name
         """Return current pressed state of button C."""
-        self.read_data()
-        return not bool(self.buffer[5] & 0x02)
+        return self.values[2]
 
     @property
     def button_Z(self):  # pylint: disable=invalid-name
         """Return current pressed state of button Z."""
-        self.read_data()
-        return not bool(self.buffer[5] & 0x01)
+        return self.values[3]
 
     @property
     def acceleration(self):
         """Return 3 tuple of accelerometer reading."""
-        self.read_data()
-        x = (self.buffer[5] & 0xC0) >> 6
-        x |= self.buffer[2] << 2
-        y = (self.buffer[5] & 0x30) >> 4
-        y |= self.buffer[3] << 2
-        z = (self.buffer[5] & 0x0C) >> 2
-        z |= self.buffer[4] << 2
-        return x, y, z
+        return self.values[4], self.values[5], self.values[6]

--- a/adafruit_nunchuk/nunchuk.py
+++ b/adafruit_nunchuk/nunchuk.py
@@ -22,10 +22,7 @@ Implementation Notes
 
 * Adafruit CircuitPython firmware for the supported boards:
   https://github.com/adafruit/circuitpython/releases
-* Adafruit's Bus Device library: https://github.com/adafruit/Adafruit_CircuitPython_BusDevice
 """
-import time
-from adafruit_bus_device.i2c_device import I2CDevice
 from adafruit_nunchuk import NunchukBase
 
 __version__ = "0.0.0-auto.0"
@@ -33,35 +30,35 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Nunchuk.git"
 
 _DEFAULT_ADDRESS = 0x52
 
+
 class Nunchuk(NunchukBase):
     """Class which provides interface to Nintendo Nunchuk controller."""
 
     def __init__(self, i2c, address=_DEFAULT_ADDRESS):
         super().__init__(i2c, address=address)
 
-
     @property
     def joystick(self):
         """Return tuple of current joystick position."""
-        self._read_data()
+        self.read_data()
         return self.buffer[0], self.buffer[1]
 
     @property
     def button_C(self):  # pylint: disable=invalid-name
         """Return current pressed state of button C."""
-        self._read_data()
+        self.read_data()
         return not bool(self.buffer[5] & 0x02)
 
     @property
     def button_Z(self):  # pylint: disable=invalid-name
         """Return current pressed state of button Z."""
-        self._read_data()
+        self.read_data()
         return not bool(self.buffer[5] & 0x01)
 
     @property
     def acceleration(self):
         """Return 3 tuple of accelerometer reading."""
-        self._read_data()
+        self.read_data()
         x = (self.buffer[5] & 0xC0) >> 6
         x |= self.buffer[2] << 2
         y = (self.buffer[5] & 0x30) >> 4
@@ -69,4 +66,3 @@ class Nunchuk(NunchukBase):
         z = (self.buffer[5] & 0x0C) >> 2
         z |= self.buffer[4] << 2
         return x, y, z
-

--- a/adafruit_nunchuk/nunchuk.py
+++ b/adafruit_nunchuk/nunchuk.py
@@ -8,7 +8,7 @@
 
 CircuitPython library for Nintendo Nunchuk controller
 
-* Author(s): Carter Nelson
+* Author(s): Carter Nelson, John Furcean
 
 Implementation Notes
 --------------------

--- a/adafruit_nunchuk/nunchuk.py
+++ b/adafruit_nunchuk/nunchuk.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: 2019 Carter Nelson for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+"""
+`adafruit_nunchuk.nunchuck`
+================================================================================
+
+CircuitPython library for Nintendo Nunchuk controller
+
+* Author(s): Carter Nelson
+
+Implementation Notes
+--------------------
+
+**Hardware:**
+
+* `Wii Remote Nunchuk <https://en.wikipedia.org/wiki/Wii_Remote#Nunchuk>`_
+* `Wiichuck <https://www.adafruit.com/product/342>`_
+
+**Software and Dependencies:**
+
+* Adafruit CircuitPython firmware for the supported boards:
+  https://github.com/adafruit/circuitpython/releases
+* Adafruit's Bus Device library: https://github.com/adafruit/Adafruit_CircuitPython_BusDevice
+"""
+import time
+from adafruit_bus_device.i2c_device import I2CDevice
+from adafruit_nunchuk import NunchukBase
+
+__version__ = "0.0.0-auto.0"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Nunchuk.git"
+
+_DEFAULT_ADDRESS = 0x52
+
+class Nunchuk(NunchukBase):
+    """Class which provides interface to Nintendo Nunchuk controller."""
+
+    def __init__(self, i2c, address=_DEFAULT_ADDRESS):
+        super().__init__(i2c, address=address)
+
+
+    @property
+    def joystick(self):
+        """Return tuple of current joystick position."""
+        self._read_data()
+        return self.buffer[0], self.buffer[1]
+
+    @property
+    def button_C(self):  # pylint: disable=invalid-name
+        """Return current pressed state of button C."""
+        self._read_data()
+        return not bool(self.buffer[5] & 0x02)
+
+    @property
+    def button_Z(self):  # pylint: disable=invalid-name
+        """Return current pressed state of button Z."""
+        self._read_data()
+        return not bool(self.buffer[5] & 0x01)
+
+    @property
+    def acceleration(self):
+        """Return 3 tuple of accelerometer reading."""
+        self._read_data()
+        x = (self.buffer[5] & 0xC0) >> 6
+        x |= self.buffer[2] << 2
+        y = (self.buffer[5] & 0x30) >> 4
+        y |= self.buffer[3] << 2
+        z = (self.buffer[5] & 0x0C) >> 2
+        z |= self.buffer[4] << 2
+        return x, y, z
+

--- a/adafruit_nunchuk/udraw.py
+++ b/adafruit_nunchuk/udraw.py
@@ -6,7 +6,7 @@
 ================================================================================
 CircuitPython library for the Nintendo Wii uDraw GameTablet
 
-* Author(s): David Glaude
+* Author(s): David Glaude, John Furcean
 
 Implementation Notes
 --------------------

--- a/adafruit_nunchuk/udraw.py
+++ b/adafruit_nunchuk/udraw.py
@@ -40,7 +40,7 @@ class uDraw(NunchukBase):
     def pressure(self):
         """Return current pen pressure."""
         self.read_data()
-        return (self.buffer[3])
+        return self.buffer[3]
 
     @property
     def button_pen(self):
@@ -64,4 +64,6 @@ class uDraw(NunchukBase):
     def position(self):
         """Return tuple of current position."""
         self.read_data()
-        return ((self.buffer[2] & 0x0F) << 8 | self.buffer[0]), ((self.buffer[2] & 0xF0) << 4 | self.buffer[1])
+        return ((self.buffer[2] & 0x0F) << 8 | self.buffer[0]), (
+            (self.buffer[2] & 0xF0) << 4 | self.buffer[1]
+        )

--- a/adafruit_nunchuk/udraw.py
+++ b/adafruit_nunchuk/udraw.py
@@ -30,7 +30,7 @@ _I2C_INIT_DELAY = 0.1
 _I2C_READ_DELAY = 0.01
 
 
-class uDraw(NunchukBase):
+class UDraw(NunchukBase):
     """Class which provides interface to the uDraw GameTablet."""
 
     def __init__(self, i2c, address=_DEFAULT_ADDRESS):

--- a/adafruit_nunchuk/udraw.py
+++ b/adafruit_nunchuk/udraw.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Copyright (c) 2021 David Glaude
+#
+# SPDX-License-Identifier: MIT
+"""
+`udraw`
+================================================================================
+CircuitPython library for the Nintendo Wii uDraw GameTablet
+
+* Author(s): David Glaude
+
+Implementation Notes
+--------------------
+
+**Hardware:**
+
+* Wii uDraw GameTablet http://wiibrew.org/wiki/Wiimote/Extension_Controllers/Classic_Controller
+
+**Software and Dependencies:**
+
+* Adafruit CircuitPython firmware for the supported boards:
+  https://github.com/adafruit/circuitpython/releases
+* Adafruit's Bus Device library: https://github.com/adafruit/Adafruit_CircuitPython_BusDevice
+`adafruit_nunchuk.classic_controller`
+"""
+from adafruit_nunchuk import NunchukBase
+
+
+_DEFAULT_ADDRESS = 0x52
+_I2C_INIT_DELAY = 0.1
+_I2C_READ_DELAY = 0.01
+
+
+class uDraw(NunchukBase):
+    """Class which provides interface to the uDraw GameTablet."""
+
+    def __init__(self, i2c, address=_DEFAULT_ADDRESS):
+        super().__init__(i2c, address=address)
+
+    @property
+    def pressure(self):
+        """Return current pen pressure."""
+        self.read_data()
+        return (self.buffer[3])
+
+    @property
+    def button_pen(self):
+        """Return current pressed state of the PEN button"""
+        self.read_data()
+        return bool((self.buffer[5] & 0x04) >> 2)
+
+    @property
+    def button_c(self):
+        """Return current pressed state of the C button"""
+        self.read_data()
+        return not bool((self.buffer[5] & 0x02) >> 1)
+
+    @property
+    def button_z(self):
+        """Return current pressed state of the Z button"""
+        self.read_data()
+        return not bool((self.buffer[5] & 0x01))
+
+    @property
+    def position(self):
+        """Return tuple of current position."""
+        self.read_data()
+        return ((self.buffer[2] & 0x0F) << 8 | self.buffer[0]), ((self.buffer[2] & 0xF0) << 4 | self.buffer[1])

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,7 @@ extensions = [
 # Uncomment the below if you use native CircuitPython modules such as
 # digitalio, micropython and busio. List the modules you use. Without it, the
 # autodoc module docs will fail to generate with a warning.
-# autodoc_mock_imports = ["digitalio", "busio"]
+autodoc_mock_imports = ["adafruit_bus_device"]
 
 
 intersphinx_mapping = {

--- a/examples/classic_controller_simpletest.py
+++ b/examples/classic_controller_simpletest.py
@@ -52,4 +52,3 @@ while True:
         print("Button Pressed: Plus")
     if controller.button_minus:
         print("Button Pressed: Minus")
-    

--- a/examples/classic_controller_simpletest.py
+++ b/examples/classic_controller_simpletest.py
@@ -5,7 +5,6 @@ import board
 from adafruit_nunchuk.classic_controller import ClassicController
 
 controller = ClassicController(board.I2C())
-
 while True:
 
     # Right Joystick: (0-31,0-31), middle is (16,16)
@@ -15,12 +14,6 @@ while True:
     # Left Joystick: (0-63,063), middle is (32,32)
     if controller.joystick_L != (32, 32):
         print(f"Left Joystick (x,y): {controller.joystick_L}")
-
-    # Triggers: 0-31
-    if controller.trigger_R > 0:
-        print(f"Right Trigger: {controller.trigger_R}")
-    if controller.trigger_L > 0:
-        print(f"Left Trigger: {controller.trigger_L}")
 
     # DPad: True or False
     if controller.dpad_D:
@@ -45,6 +38,10 @@ while True:
         print("Button Pressed: X")
     if controller.button_Y:
         print("Button Pressed: Y")
+    if controller.button_RT:
+        print("Button Pressed: RT")
+    if controller.button_LT:
+        print("Button Pressed: LT")
     if controller.button_home:
         print("Button Pressed: Home")
     if controller.button_start:
@@ -55,3 +52,4 @@ while True:
         print("Button Pressed: Plus")
     if controller.button_minus:
         print("Button Pressed: Minus")
+    

--- a/examples/classic_controller_simpletest.py
+++ b/examples/classic_controller_simpletest.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 John Furcean
+# SPDX-FileCopyrightText: Copyright (c) 2021 John Furcean
 #
 # SPDX-License-Identifier: MIT
 import board

--- a/examples/classic_controller_simpletest.py
+++ b/examples/classic_controller_simpletest.py
@@ -18,9 +18,9 @@ while True:
 
     # Triggers: 0-31
     if controller.trigger_right > 0:
-        print(f"Right Trigger (x,y): {controller.trigger_right}")
+        print(f"Right Trigger: {controller.trigger_right}")
     if controller.trigger_left > 0:
-        print(f"Left Trigger (x,y): {controller.trigger_left}")
+        print(f"Left Trigger: {controller.trigger_left}")
 
     # DPad: True or False
     if controller.dpad_down:

--- a/examples/classic_controller_simpletest.py
+++ b/examples/classic_controller_simpletest.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: 2021 John Furcean
+#
+# SPDX-License-Identifier: MIT
+import board
+from adafruit_nunchuk.classic_controller import ClassicController
+
+controller = ClassicController(board.I2C())
+
+while True:
+
+    # Right Joystick: (0-31,0-31), middle is (16,16)
+    if controller.joystick_right != (16, 16):
+        print(f"Right Joystick (x,y): {controller.joystick_right}")
+
+    # Left Joystick: (0-63,063), middle is (32,32)
+    if controller.joystick_left != (32, 32):
+        print(f"Left Joystick (x,y): {controller.joystick_left}")
+
+    # Triggers: 0-31
+    if controller.trigger_right > 0:
+        print(f"Right Trigger (x,y): {controller.trigger_right}")
+    if controller.trigger_left > 0:
+        print(f"Left Trigger (x,y): {controller.trigger_left}")
+
+    # DPad: True or False
+    if controller.dpad_down:
+        print("D-Pad Down Pressed")
+    if controller.dpad_up:
+        print("D-Pad Up Pressed")
+    if controller.dpad_left:
+        print("D-Pad Left Pressed")
+    if controller.dpad_right:
+        print("D-Pad Right Pressed")
+
+    # Buttons: True of False
+    if controller.button_zr:
+        print("Button Pressed: Zr")
+    if controller.button_zl:
+        print("Button Pressed: Zl")
+    if controller.button_a:
+        print("Button Pressed: A")
+    if controller.button_b:
+        print("Button Pressed: B")
+    if controller.button_x:
+        print("Button Pressed: X")
+    if controller.button_y:
+        print("Button Pressed: Y")
+    if controller.button_home:
+        print("Button Pressed: HOME")
+    if controller.button_start:
+        print("Button Pressed: START")
+    if controller.button_select:
+        print("Button Pressed: SELECT")

--- a/examples/classic_controller_simpletest.py
+++ b/examples/classic_controller_simpletest.py
@@ -9,45 +9,49 @@ controller = ClassicController(board.I2C())
 while True:
 
     # Right Joystick: (0-31,0-31), middle is (16,16)
-    if controller.joystick_right != (16, 16):
-        print(f"Right Joystick (x,y): {controller.joystick_right}")
+    if controller.joystick_R != (16, 16):
+        print(f"Right Joystick (x,y): {controller.joystick_R}")
 
     # Left Joystick: (0-63,063), middle is (32,32)
-    if controller.joystick_left != (32, 32):
-        print(f"Left Joystick (x,y): {controller.joystick_left}")
+    if controller.joystick_L != (32, 32):
+        print(f"Left Joystick (x,y): {controller.joystick_L}")
 
     # Triggers: 0-31
-    if controller.trigger_right > 0:
-        print(f"Right Trigger: {controller.trigger_right}")
-    if controller.trigger_left > 0:
-        print(f"Left Trigger: {controller.trigger_left}")
+    if controller.trigger_R > 0:
+        print(f"Right Trigger: {controller.trigger_R}")
+    if controller.trigger_L > 0:
+        print(f"Left Trigger: {controller.trigger_L}")
 
     # DPad: True or False
-    if controller.dpad_down:
+    if controller.dpad_D:
         print("D-Pad Down Pressed")
-    if controller.dpad_up:
+    if controller.dpad_U:
         print("D-Pad Up Pressed")
-    if controller.dpad_left:
+    if controller.dpad_L:
         print("D-Pad Left Pressed")
-    if controller.dpad_right:
+    if controller.dpad_R:
         print("D-Pad Right Pressed")
 
     # Buttons: True of False
-    if controller.button_zr:
-        print("Button Pressed: Zr")
-    if controller.button_zl:
-        print("Button Pressed: Zl")
-    if controller.button_a:
+    if controller.button_ZR:
+        print("Button Pressed: ZR")
+    if controller.button_ZL:
+        print("Button Pressed: ZL")
+    if controller.button_A:
         print("Button Pressed: A")
-    if controller.button_b:
+    if controller.button_B:
         print("Button Pressed: B")
-    if controller.button_x:
+    if controller.button_X:
         print("Button Pressed: X")
-    if controller.button_y:
+    if controller.button_Y:
         print("Button Pressed: Y")
     if controller.button_home:
-        print("Button Pressed: HOME")
+        print("Button Pressed: Home")
     if controller.button_start:
-        print("Button Pressed: START")
+        print("Button Pressed: Start")
     if controller.button_select:
-        print("Button Pressed: SELECT")
+        print("Button Pressed: Select")
+    if controller.button_plus:
+        print("Button Pressed: Plus")
+    if controller.button_minus:
+        print("Button Pressed: Minus")

--- a/examples/nunchuk_accel_mouse.py
+++ b/examples/nunchuk_accel_mouse.py
@@ -2,11 +2,12 @@
 # SPDX-License-Identifier: MIT
 
 import board
+import usb_hid
 from adafruit_hid.mouse import Mouse
-import adafruit_nunchuk
+from adafruit_nunchuk.nunchuk import Nunchuk
 
-m = Mouse()
-nc = adafruit_nunchuk.Nunchuk(board.I2C())
+m = Mouse(usb_hid.devices)
+nc = Nunchuk(board.I2C())
 
 centerX = 120
 centerY = 110

--- a/examples/nunchuk_analog_mouse.py
+++ b/examples/nunchuk_analog_mouse.py
@@ -2,11 +2,12 @@
 # SPDX-License-Identifier: MIT
 
 import board
+import usb_hid
 from adafruit_hid.mouse import Mouse
-import adafruit_nunchuk
+from adafruit_nunchuk.nunchuk import Nunchuk
 
-m = Mouse()
-nc = adafruit_nunchuk.Nunchuk(board.I2C())
+m = Mouse(usb_hid.devices)
+nc = Nunchuk(board.I2C())
 
 centerX = 128
 centerY = 128

--- a/examples/nunchuk_mouse.py
+++ b/examples/nunchuk_mouse.py
@@ -2,13 +2,14 @@
 # SPDX-License-Identifier: MIT
 
 import board
+import usb_hid
 from adafruit_hid.mouse import Mouse
-import adafruit_nunchuk
+from adafruit_nunchuk.nunchuk import Nunchuk
 
 THRESHOLD = 10
 
-m = Mouse()
-nc = adafruit_nunchuk.Nunchuk(board.I2C())
+m = Mouse(usb_hid.devices)
+nc = Nunchuk(board.I2C())
 
 while True:
     x, y = nc.joystick

--- a/examples/nunchuk_simpletest.py
+++ b/examples/nunchuk_simpletest.py
@@ -5,7 +5,7 @@ import time
 import board
 from adafruit_nunchuk.nunchuk import Nunchuk
 
-nc = adafruit_nunchuk.Nunchuk(board.I2C())
+nc = Nunchuk(board.I2C())
 
 while True:
     x, y = nc.joystick

--- a/examples/nunchuk_simpletest.py
+++ b/examples/nunchuk_simpletest.py
@@ -3,7 +3,7 @@
 
 import time
 import board
-import adafruit_nunchuk
+from adafruit_nunchuk.nunchuk import Nunchuk
 
 nc = adafruit_nunchuk.Nunchuk(board.I2C())
 

--- a/examples/udraw_mouse.py
+++ b/examples/udraw_mouse.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2021 David Glaude
+#
+# SPDX-License-Identifier: MIT
+import board
+import usb_hid
+from adafruit_hid.mouse import Mouse
+from adafruit_nunchuk.udraw import UDraw
+
+udraw = UDraw(board.I2C())
+
+m = Mouse(usb_hid.devices)
+
+zDown = False
+pDown = False
+
+oldx = 4095
+oldy = 4095
+
+while True:
+
+    px, py, pen, C, Z, pressure = udraw.values
+
+    P = pen or C  # Both the C button and pen button work as LEFT mouse
+
+    # Handeling the button to create mouse click
+    if P and not pDown:
+        m.press(Mouse.LEFT_BUTTON)
+        pDown = True
+    elif not P and pDown:
+        m.release(Mouse.LEFT_BUTTON)
+        pDown = False
+
+    if Z and not zDown:
+        m.press(Mouse.RIGHT_BUTTON)
+        zDown = True
+    elif not Z and zDown:
+        m.release(Mouse.RIGHT_BUTTON)
+        zDown = False
+
+    # Values (4095,4095) mean the pen is not near the tablet
+    if px == 4095 or py == 4095:
+        oldx = 4095
+        oldy = 4095
+        continue  # We remember that the pen was raised UP
+
+    # If we reach here, the pen was UP and is now DOWN
+    if oldx == 4095 or oldy == 4095:
+        oldx = px
+        oldy = py
+        continue
+
+    if (px != oldx) or (py != oldy):  # PEN has moved we move the HID mouse
+        m.move((px - oldx), (oldy - py), 0)
+        oldx = px
+        oldy = py

--- a/examples/udraw_simpletest.py
+++ b/examples/udraw_simpletest.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2021 David Glaude
+#
+# SPDX-License-Identifier: MIT
+import board
+from adafruit_nunchuk.udraw import uDraw
+
+controller = uDraw(board.I2C())
+
+while True:
+
+    # Pressure: (8-248)
+    if controller.pressure != 8:
+        print("Pen pressure: ", controller.pressure)
+
+    if controller.position != (4095, 4095):
+        print("Pen (x,y): ", controller.position)
+
+    # Buttons: True of False
+    if controller.button_pen:
+        print("Button Pressed: PEN")
+    if controller.button_c:
+        print("Button Pressed: C")
+    if controller.button_z:
+        print("Button Pressed: Z")

--- a/examples/udraw_simpletest.py
+++ b/examples/udraw_simpletest.py
@@ -17,8 +17,8 @@ while True:
 
     # Buttons: True of False
     if controller.button_pen:
-        print("Button Pressed: PEN")
-    if controller.button_c:
+        print("Button Pressed: Pen")
+    if controller.button_C:
         print("Button Pressed: C")
-    if controller.button_z:
+    if controller.button_Z:
         print("Button Pressed: Z")

--- a/examples/udraw_simpletest.py
+++ b/examples/udraw_simpletest.py
@@ -2,9 +2,9 @@
 #
 # SPDX-License-Identifier: MIT
 import board
-from adafruit_nunchuk.udraw import uDraw
+from adafruit_nunchuk.udraw import UDraw
 
-controller = uDraw(board.I2C())
+controller = UDraw(board.I2C())
 
 while True:
 


### PR DESCRIPTION
- Converts the adafruit_nunchuck to a package to make it easier to incorporate support for additional Nunchuk extension controllers
- adds addtional support for the wii classic controller
- optimizes the read_data function for better response when reading from multiple sensors/buttons on the device