### PR TITLE
I2C Speedup

### DIFF
--- a/adafruit_nunchuk.py
+++ b/adafruit_nunchuk.py
@@ -39,12 +39,13 @@ class Nunchuk:
     Class which provides interface to Nintendo Nunchuk controller.
 
     :param i2c: The `busio.I2C` object to use.
-    :param int address: (optional) The I2C address of the device.
-    Default is 0x52.
-    :param float i2c_read_delay: (optional) The time in seconds to pause
-    between the I2C write and read. This needs to be at least 200us. A
-    conservative default of 2000us is used since some hosts may not be
-    able to achieve such timing.
+    :param address: The I2C address of the device. Default is 0x52.
+    :type address: int, optional
+    :param i2c_read_delay: The time in seconds to pause between the
+        I2C write and read. This needs to be at least 200us. A
+        conservative default of 2000us is used since some hosts may
+        not be able to achieve such timing.
+    :type i2c_read_delay: float, optional
     """
 
     def __init__(self, i2c, address=0x52, i2c_read_delay=0.002):

--- a/adafruit_nunchuk.py
+++ b/adafruit_nunchuk.py
@@ -35,7 +35,17 @@ _I2C_INIT_DELAY = 0.1
 
 
 class Nunchuk:
-    """Class which provides interface to Nintendo Nunchuk controller."""
+    """
+    Class which provides interface to Nintendo Nunchuk controller.
+
+    :param i2c: The `busio.I2C` object to use.
+    :param int address: (optional) The I2C address of the device.
+    Default is 0x52.
+    :param float i2c_read_delay: (optional) The time in seconds to pause
+    between the I2C write and read. This needs to be at least 200us. A
+    conservative default of 2000us is used since some hosts may not be
+    able to achieve such timing.
+    """
 
     def __init__(self, i2c, address=0x52, i2c_read_delay=0.002):
         self.buffer = bytearray(8)

--- a/adafruit_nunchuk.py
+++ b/adafruit_nunchuk.py
@@ -48,17 +48,16 @@ from adafruit_bus_device.i2c_device import I2CDevice
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Nunchuk.git"
 
-_DEFAULT_ADDRESS = 0x52
 _I2C_INIT_DELAY = 0.1
-_I2C_READ_DELAY = 0.01
 
 
 class Nunchuk:
     """Class which provides interface to Nintendo Nunchuk controller."""
 
-    def __init__(self, i2c, address=_DEFAULT_ADDRESS):
-        self.buffer = bytearray(6)
+    def __init__(self, i2c, address=0x52, i2c_read_delay=0.002):
+        self.buffer = bytearray(8)
         self.i2c_device = I2CDevice(i2c, address)
+        self._i2c_read_delay = i2c_read_delay
         time.sleep(_I2C_INIT_DELAY)
         with self.i2c_device as i2c_dev:
             # turn off encrypted data
@@ -100,9 +99,7 @@ class Nunchuk:
 
     def _read_register(self, address):
         with self.i2c_device as i2c:
-            time.sleep(_I2C_READ_DELAY)
             i2c.write(address)
-            time.sleep(_I2C_READ_DELAY)
+            time.sleep(self._i2c_read_delay)  # at least 200us
             i2c.readinto(self.buffer)
-        time.sleep(_I2C_READ_DELAY)
         return self.buffer


### PR DESCRIPTION
This PR should significantly speed up the I2C transaction and greatly improve the performance of this library. The code change is trivial, but there is a lot of history behind it.

First off, this library was originally written as a simple port of existing Arduino libraries. The huge delays included in the I2C transaction came from there. Some attempts were made to reduce or remove these. Using a repeated start was also attempted. These efforts had mixed success. It could be made to work fast on one platform, but then break on another. Obviously there was some subtle timing requirement that was not being satisfied. But with no real information (no datasheet) to go on, the exact nature of this remained unknown. So the existing delays were simply left in place.

Some recent PR's (#17 and #18) have brought this issue back into the light. Various work arounds were discussed as a way to speed up the library - all assuming the huge delays were still necessary. See those PR threads for more info. Progress was made, but then at some point the idea of removing the delays was again attempted and seemed to work. As before, this worked on some platforms, but not others. This motivated the investigation to snoop actual Wiimote-to-Nunchuk traffic to finally have some idea of what the "requirements" are. The results are documented here:
https://github.com/adafruit/Adafruit_CircuitPython_Nunchuk/issues/2#issuecomment-765816539

Based on those findings, it seems the critical timing requirement is an O(200us) delay between the write and read transactions. On some slower boards, this can happen naturally without any explicit delay between the two lines of code. But on faster boards, the delay would be <200us and the Nunchuk would NACK on the read. Adding an explicit delay fixed this for all boards. However, the ability to actually generate a 200us delay in Python is a mixed bag. Some hosts can do that, others can not. For those that can not, the attempt results in essentially zero delay. Therefore, this PR uses a conservative default of 2000us which seems to work on all platforms. The value is available as a parameter to allow fine tuning if desired and possible.

Other misc:

- The read buffer has been increased to 8 bytes to match the Wiimote behavior, even though the last two bytes appear to be meaningless. Maybe 3rd party Nunchuks expect that behavior in some weird way?
- The `_I2C_INIT_DELAY` is being left in place for now. Can it be reduced? Unknown. Can investigate for a future PR.
- The current API is also unchanged for now. Also something for a future PR - maybe provide something that returns all values from the single I2C transaction? Like in a named tuple or something?

Tested on:

- MO : Trinket M0 and QT Py
- M4 : Itsy M4
- Blinka: MCP2221 on linux and RPI4

