### PR TITLE
Add values property

### DIFF
--- a/adafruit_nunchuk.py
+++ b/adafruit_nunchuk.py
@@ -5,14 +5,22 @@
 """
 `adafruit_nunchuk`
 ================================================================================
+
 CircuitPython library for Nintendo Nunchuk controller
+
+
 * Author(s): Carter Nelson
+
 Implementation Notes
 --------------------
+
 **Hardware:**
+
 * `Wii Remote Nunchuk <https://en.wikipedia.org/wiki/Wii_Remote#Nunchuk>`_
 * `Wiichuck <https://www.adafruit.com/product/342>`_
+
 **Software and Dependencies:**
+
 * Adafruit CircuitPython firmware for the supported boards:
   https://github.com/adafruit/circuitpython/releases
 * Adafruit's Bus Device library: https://github.com/adafruit/Adafruit_CircuitPython_BusDevice
@@ -71,9 +79,7 @@ class Nunchuk:
         return self.buffer[0], self.buffer[1]
 
     @property
-    def button_C(
-        self,
-    ):  # pylint: disable=invalid-name
+    def button_C(self):  # pylint: disable=invalid-name
         """Return current pressed state of button C."""
         return not bool(self.buffer[5] & 0x02)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,7 @@ extensions = [
 # Uncomment the below if you use native CircuitPython modules such as
 # digitalio, micropython and busio. List the modules you use. Without it, the
 # autodoc module docs will fail to generate with a warning.
-# autodoc_mock_imports = ["digitalio", "busio"]
+autodoc_mock_imports = ["adafruit_bus_device"]
 
 
 intersphinx_mapping = {

--- a/examples/nunchuk_accel_mouse.py
+++ b/examples/nunchuk_accel_mouse.py
@@ -27,6 +27,7 @@ CHECK_COUNT = 0
 #    print((0 if nc.button_C else 1, 0 if nc.button_Z else 1))
 
 while True:
+    nc.read_data()
     accel = nc.acceleration
     #    print(accel)
     #    x, y = nc.joystick

--- a/examples/nunchuk_analog_mouse.py
+++ b/examples/nunchuk_analog_mouse.py
@@ -27,6 +27,7 @@ CHECK_COUNT = 0
 #    print((0 if nc.button_C else 1, 0 if nc.button_Z else 1))
 
 while True:
+    nc.read_data()
     x, y = nc.joystick
     # Eliminate spurious reads
     if x == 255 or y == 255:

--- a/examples/nunchuk_mouse.py
+++ b/examples/nunchuk_mouse.py
@@ -12,6 +12,7 @@ m = Mouse(usb_hid.devices)
 nc = adafruit_nunchuk.Nunchuk(board.I2C())
 
 while True:
+    nc.read_data()
     x, y = nc.joystick
     x = (x - 128) // 2
     y = (128 - y) // 2

--- a/examples/nunchuk_simpletest.py
+++ b/examples/nunchuk_simpletest.py
@@ -8,12 +8,12 @@ import adafruit_nunchuk
 nc = adafruit_nunchuk.Nunchuk(board.I2C())
 
 while True:
-    x, y = nc.joystick
-    ax, ay, az = nc.acceleration
-    print("joystick = {},{}".format(x, y))
-    print("accceleration ax={}, ay={}, az={}".format(ax, ay, az))
-    if nc.button_C:
+    values = nc.values
+    print("joystick = {},{}".format(values.sx, values.sy))
+    print("accceleration ax={}, ay={}, az={}".format(values.ax, values.ay, values.az))
+    if values.bc:
         print("button C")
-    if nc.button_Z:
+    if values.bz:
         print("button Z")
+
     time.sleep(0.5)


### PR DESCRIPTION
This exposes the `read_data()` to users so it can operate like most of the Arduino versions of this library (e.g. [WiiChuck](https://github.com/madhephaestus/WiiChuck)). They can call the `read_data()` function at the top of their loop to pull the data and then use the properties throughout to retrieve the data. The properties themselves no longer call `read_data()`. Likewise, this offers a new property `values` that reads the data once and passes back a named tuple of all of the properties. The named tuple uses the naming conventions of the data diagram from [WiiBrew](https://wiibrew.org/wiki/Wiimote/Extension_Controllers/Nunchuck). I am open to other suggestions, though I would like to be consistent because there are several other extension controllers I want to base off of this library.