### PR TITLE
refactor to add support for additional nunchuk accessories

### DIFF
--- a/adafruit_nunchuk/__init__.py
+++ b/adafruit_nunchuk/__init__.py
@@ -6,10 +6,10 @@
 `adafruit_nunchuk`
 ================================================================================
 
-CircuitPython library for Nintendo Nunchuk controller
+CircuitPython driver for Nintento Nunchuk Accessories
 
 
-* Author(s): Carter Nelson
+* Author(s): Carter Nelson, John Furcean
 
 Implementation Notes
 --------------------
@@ -18,6 +18,7 @@ Implementation Notes
 
 * `Wii Remote Nunchuk <https://en.wikipedia.org/wiki/Wii_Remote#Nunchuk>`_
 * `Wiichuck <https://www.adafruit.com/product/342>`_
+* `Adafruit Wii Nunchuck Breakout Adapter <https://www.adafruit.com/product/4836>`_
 
 **Software and Dependencies:**
 
@@ -26,7 +27,6 @@ Implementation Notes
 * Adafruit's Bus Device library: https://github.com/adafruit/Adafruit_CircuitPython_BusDevice
 """
 import time
-from collections import namedtuple
 from adafruit_bus_device.i2c_device import I2CDevice
 
 __version__ = "0.0.0-auto.0"
@@ -35,9 +35,9 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Nunchuk.git"
 _I2C_INIT_DELAY = 0.1
 
 
-class Nunchuk:
+class NunchukBase:  # pylint: disable=too-few-public-methods
     """
-    Class which provides interface to Nintendo Nunchuk controller.
+    Base Class which provides interface to Nintendo Nunchuk Accessories.
 
     :param i2c: The `busio.I2C` object to use.
     :param address: The I2C address of the device. Default is 0x52.
@@ -48,11 +48,6 @@ class Nunchuk:
         not be able to achieve such timing.
     :type i2c_read_delay: float, optional
     """
-
-    _Values = namedtuple("Values", ("joystick", "buttons", "acceleration"))
-    _Joystick = namedtuple("Joystick", ("x", "y"))
-    _Buttons = namedtuple("Buttons", ("C", "Z"))
-    _Acceleration = namedtuple("Acceleration", ("x", "y", "z"))
 
     def __init__(self, i2c, address=0x52, i2c_read_delay=0.002):
         self.buffer = bytearray(8)
@@ -65,52 +60,6 @@ class Nunchuk:
             i2c_dev.write(b"\xF0\x55")
             time.sleep(_I2C_INIT_DELAY)
             i2c_dev.write(b"\xFB\x00")
-
-    @property
-    def values(self):
-        """The current state of all values."""
-        self._read_data()
-        return self._Values(
-            self._joystick(do_read=False),
-            self._buttons(do_read=False),
-            self._acceleration(do_read=False),
-        )
-
-    @property
-    def joystick(self):
-        """The current joystick position."""
-        return self._joystick()
-
-    @property
-    def buttons(self):  # pylint: disable=invalid-name
-        """The current pressed state of button Z."""
-        return self._buttons()
-
-    @property
-    def acceleration(self):
-        """The current accelerometer reading."""
-        return self._acceleration()
-
-    def _joystick(self, do_read=True):
-        if do_read:
-            self._read_data()
-        return self._Joystick(self.buffer[0], self.buffer[1])  # x, y
-
-    def _buttons(self, do_read=True):
-        if do_read:
-            self._read_data()
-        return self._Buttons(
-            not bool(self.buffer[5] & 0x02), not bool(self.buffer[5] & 0x01)  # C  # Z
-        )
-
-    def _acceleration(self, do_read=True):
-        if do_read:
-            self._read_data()
-        return self._Acceleration(
-            ((self.buffer[5] & 0xC0) >> 6) | (self.buffer[2] << 2),  # ax
-            ((self.buffer[5] & 0x30) >> 4) | (self.buffer[3] << 2),  # ay
-            ((self.buffer[5] & 0x0C) >> 2) | (self.buffer[4] << 2),  # az
-        )
 
     def _read_data(self):
         return self._read_register(b"\x00")

--- a/adafruit_nunchuk/classic_controller.py
+++ b/adafruit_nunchuk/classic_controller.py
@@ -1,0 +1,156 @@
+# SPDX-FileCopyrightText: 2019 Carter Nelson for Adafruit Industries
+
+# SPDX-License-Identifier: MIT
+
+"""
+`adafruit_nunchuk.classic_controller`
+================================================================================
+
+CircuitPython library for Wii Nintendo Classic Controller & Classic Controller Plus
+
+
+* Author(s): Carter Nelson, John Furcean
+
+Implementation Notes
+--------------------
+
+**Hardware:**
+
+* `Wii Remote Nunchuk <https://en.wikipedia.org/wiki/Wii_Remote#Nunchuk>`_
+* `Wiichuck <https://www.adafruit.com/product/342>`_
+* `Adafruit Wii Nunchuck Breakout Adapter <https://www.adafruit.com/product/4836>`_
+
+**Software and Dependencies:**
+
+* Adafruit CircuitPython firmware for the supported boards:
+  https://github.com/adafruit/circuitpython/releases
+* Adafruit's Bus Device library: https://github.com/adafruit/Adafruit_CircuitPython_BusDevice
+"""
+from collections import namedtuple
+from adafruit_nunchuk import NunchukBase
+
+__version__ = "0.0.0-auto.0"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Nunchuk.git"
+
+
+class ClassicController(NunchukBase):
+    """
+    Class which provides interface to Nintendo Wii Classic Controller.
+
+    :param i2c: The `busio.I2C` object to use.
+    :param address: The I2C address of the device. Default is 0x52.
+    :type address: int, optional
+    :param i2c_read_delay: The time in seconds to pause between the
+        I2C write and read. This needs to be at least 200us. A
+        conservative default of 2000us is used since some hosts may
+        not be able to achieve such timing.
+    :type i2c_read_delay: float, optional
+    """
+
+    _Values = namedtuple("Values", ("joysticks", "buttons", "dpad", "triggers"))
+    _Joysticks = namedtuple("Joysticks", ("rx", "ry", "lx", "ly"))
+    _Buttons = namedtuple(
+        "Buttons",
+        (
+            "A",
+            "B",
+            "X",
+            "Y",
+            "R",
+            "L",
+            "ZR",
+            "ZL",
+            "start",
+            "select",
+            "home",
+            "plus",
+            "minus",
+        ),
+    )
+    _Dpad = namedtuple("Dpad", ("up", "down", "right", "left"))
+    _Triggers = namedtuple("Trigers", ("right", "left"))
+
+    def __init__(self, i2c, address=0x52, i2c_read_delay=0.002):
+        super().__init__(i2c, address=address, i2c_read_delay=i2c_read_delay)
+
+    @property
+    def values(self):
+        """The current state of all values."""
+        self._read_data()
+        return self._Values(
+            self._joysticks(do_read=False),
+            self._buttons(do_read=False),
+            self._dpad(do_read=False),
+            self._triggers(do_read=False),
+        )
+
+    @property
+    def joysticks(self):
+        """The current joysticks positions."""
+        return self._joysticks()
+
+    @property
+    def buttons(self):
+        """The current pressed state of all buttons."""
+        return self._buttons()
+
+    @property
+    def dpad(self):
+        """The current pressed state of the dpad."""
+        return self._dpad()
+
+    @property
+    def triggers(self):
+        """The current accelerometer reading."""
+        return self._triggers()
+
+    def _joysticks(self, do_read=True):
+        if do_read:
+            self._read_data()
+        return self._Joysticks(
+            (
+                (self.buffer[0] & 0xC0) >> 3
+                | (self.buffer[1] & 0xC0) >> 5
+                | (self.buffer[2] & 0x80) >> 7
+            ),  # rx
+            self.buffer[2] & 0x1F,  # ry
+            self.buffer[0] & 0x3F,  # lx
+            self.buffer[1] & 0x3F,  # ly
+        )
+
+    def _buttons(self, do_read=True):
+        if do_read:
+            self._read_data()
+        return self._Buttons(
+            not bool(self._read_data()[5] & 0x10),  # A
+            not bool(self._read_data()[5] & 0x40),  # B
+            not bool(self._read_data()[5] & 0x8),  # X
+            not bool(self._read_data()[5] & 0x20),  # Y
+            not bool(self._read_data()[4] & 0x2),  # R
+            not bool(self._read_data()[4] & 0x20),  # L
+            not bool(self._read_data()[5] & 0x4),  # ZR
+            not bool(self._read_data()[5] & 0x80),  # ZL
+            not bool(self._read_data()[4] & 0x4),  # start
+            not bool(self._read_data()[4] & 0x10),  # select
+            not bool(self._read_data()[4] & 0x8),  # home
+            not bool(self._read_data()[4] & 0x4),  # plus
+            not bool(self._read_data()[4] & 0x10),  # minus
+        )
+
+    def _dpad(self, do_read=True):
+        if do_read:
+            self._read_data()
+        return self._Dpad(
+            not bool(self._read_data()[5] & 0x1),  # UP
+            not bool(self._read_data()[4] & 0x40),  # DOWN
+            not bool(self._read_data()[4] & 0x80),  # RIGHT
+            not bool(self._read_data()[5] & 0x2),  # LEFT
+        )
+
+    def _triggers(self, do_read=True):
+        if do_read:
+            self._read_data()
+        return self._Triggers(
+            self._read_data()[3] & 0x1F,  # right
+            (self.buffer[2] & 0x60) >> 2 | (self.buffer[3] & 0xE0) >> 5,  # left
+        )

--- a/adafruit_nunchuk/nunchuk.py
+++ b/adafruit_nunchuk/nunchuk.py
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: 2019 Carter Nelson for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+"""
+`adafruit_nunchuk.nunchuck`
+================================================================================
+
+CircuitPython driver for Nintento Nunchuk Accessories
+
+
+* Author(s): Carter Nelson, John Furcean
+
+Implementation Notes
+--------------------
+
+**Hardware:**
+
+* `Wii Remote Nunchuk <https://en.wikipedia.org/wiki/Wii_Remote#Nunchuk>`_
+* `Wiichuck <https://www.adafruit.com/product/342>`_
+* `Adafruit Wii Nunchuck Breakout Adapter <https://www.adafruit.com/product/4836>`_
+
+**Software and Dependencies:**
+
+* Adafruit CircuitPython firmware for the supported boards:
+  https://github.com/adafruit/circuitpython/releases
+* Adafruit's Bus Device library: https://github.com/adafruit/Adafruit_CircuitPython_BusDevice
+"""
+from collections import namedtuple
+from adafruit_nunchuk import NunchukBase
+
+__version__ = "0.0.0-auto.0"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Nunchuk.git"
+
+
+class Nunchuk(NunchukBase):
+    """
+    Class which provides interface to Nintendo Nunchuk controller.
+
+    :param i2c: The `busio.I2C` object to use.
+    :param address: The I2C address of the device. Default is 0x52.
+    :type address: int, optional
+    :param i2c_read_delay: The time in seconds to pause between the
+        I2C write and read. This needs to be at least 200us. A
+        conservative default of 2000us is used since some hosts may
+        not be able to achieve such timing.
+    :type i2c_read_delay: float, optional
+    """
+
+    _Values = namedtuple("Values", ("joystick", "buttons", "acceleration"))
+    _Joystick = namedtuple("Joystick", ("x", "y"))
+    _Buttons = namedtuple("Buttons", ("C", "Z"))
+    _Acceleration = namedtuple("Acceleration", ("x", "y", "z"))
+
+    def __init__(self, i2c, address=0x52, i2c_read_delay=0.002):
+        super().__init__(i2c, address=address, i2c_read_delay=i2c_read_delay)
+
+    @property
+    def values(self):
+        """The current state of all values."""
+        self._read_data()
+        return self._Values(
+            self._joystick(do_read=False),
+            self._buttons(do_read=False),
+            self._acceleration(do_read=False),
+        )
+
+    @property
+    def joystick(self):
+        """The current joystick position."""
+        return self._joystick()
+
+    @property
+    def buttons(self):
+        """The current pressed state of all buttons."""
+        return self._buttons()
+
+    @property
+    def acceleration(self):
+        """The current accelerometer reading."""
+        return self._acceleration()
+
+    def _joystick(self, do_read=True):
+        if do_read:
+            self._read_data()
+        return self._Joystick(self.buffer[0], self.buffer[1])  # x, y
+
+    def _buttons(self, do_read=True):
+        if do_read:
+            self._read_data()
+        return self._Buttons(
+            not bool(self.buffer[5] & 0x02), not bool(self.buffer[5] & 0x01)  # C  # Z
+        )
+
+    def _acceleration(self, do_read=True):
+        if do_read:
+            self._read_data()
+        return self._Acceleration(
+            ((self.buffer[5] & 0xC0) >> 6) | (self.buffer[2] << 2),  # ax
+            ((self.buffer[5] & 0x30) >> 4) | (self.buffer[3] << 2),  # ay
+            ((self.buffer[5] & 0x0C) >> 2) | (self.buffer[4] << 2),  # az
+        )

--- a/examples/classic_controller_simpletest.py
+++ b/examples/classic_controller_simpletest.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2021 John Furcean
+# SPDX-License-Identifier: MIT
+
+import board
+from adafruit_nunchuk.classic_controller import ClassicController
+
+controller = ClassicController(board.I2C())
+
+while True:
+    joysticks, buttons, dpad, triggers = controller.values
+
+    # center for the right joystick is (16,16)
+    if (joysticks.rx, joysticks.ry) != (16, 16):
+        print("Right joystick = {},{}".format(joysticks.rx, joysticks.ry))
+
+    # center for the left joystick is (32,32)
+    if (joysticks.lx, joysticks.ly) != (32, 32):
+        print("Left joystick = {},{}".format(joysticks.lx, joysticks.ly))
+
+    if buttons.A:
+        print("button A")
+    if buttons.B:
+        print("button B")
+    if buttons.X:
+        print("button X")
+    if buttons.Y:
+        print("button Y")
+    if buttons.R:
+        print("button R")
+    if buttons.L:
+        print("button L")
+    if buttons.ZR:
+        print("button ZR")
+    if buttons.ZL:
+        print("button ZL")
+    if buttons.start:
+        print("button start")
+    if buttons.select:
+        print("button select")
+    if buttons.home:
+        print("button home")
+
+    if dpad.up:
+        print("dpad up")
+    if dpad.down:
+        print("dpad down")
+    if dpad.right:
+        print("dpad right")
+    if dpad.left:
+        print("dpad left")

--- a/examples/nunchuk_accel_mouse.py
+++ b/examples/nunchuk_accel_mouse.py
@@ -4,10 +4,10 @@
 import board
 import usb_hid
 from adafruit_hid.mouse import Mouse
-import adafruit_nunchuk
+from adafruit_nunchuk.nunchuk import Nunchuk
 
 m = Mouse(usb_hid.devices)
-nc = adafruit_nunchuk.Nunchuk(board.I2C())
+nc = Nunchuk(board.I2C())
 
 centerX = 120
 centerY = 110

--- a/examples/nunchuk_analog_mouse.py
+++ b/examples/nunchuk_analog_mouse.py
@@ -4,16 +4,16 @@
 import board
 import usb_hid
 from adafruit_hid.mouse import Mouse
-import adafruit_nunchuk
+from adafruit_nunchuk.nunchuk import Nunchuk
 
 m = Mouse(usb_hid.devices)
-nc = adafruit_nunchuk.Nunchuk(board.I2C())
+nc = Nunchuk(board.I2C())
 
 centerX = 128
 centerY = 128
 
-scaleX = 0.3
-scaleY = 0.3
+scaleX = 0.15
+scaleY = 0.15
 
 cDown = False
 zDown = False

--- a/examples/nunchuk_simpletest.py
+++ b/examples/nunchuk_simpletest.py
@@ -3,9 +3,9 @@
 
 import time
 import board
-import adafruit_nunchuk
+from adafruit_nunchuk.nunchuk import Nunchuk
 
-nc = adafruit_nunchuk.Nunchuk(board.I2C())
+nc = Nunchuk(board.I2C())
 
 while True:
     x, y = nc.joystick


### PR DESCRIPTION
Creating this PR to start a discussion around adding support for additional [Wiimote/Extension Controllers](http://wiibrew.org/wiki/Wiimote/Extension_Controllers) (accessories) like the Classic Controller, Guitar, DJ Table, etc Does this belong here or should this be forked as a community library and added to the community bundle? Should each accessory be its own library?

There is additional code that is ready for some of the other accessories including the ~~Drawsome/uDraw~~ uDraw tablet from @dglaude.