### PR TITLE
Adding delay for third-party nunchuks

### DIFF
--- a/adafruit_nunchuk.py
+++ b/adafruit_nunchuk.py
@@ -60,8 +60,17 @@ class Nunchuk:
     def __init__(
         self, i2c: I2C, address: int = 0x52, i2c_read_delay: float = 0.002
     ) -> None:
-        self.buffer = bytearray(8)
-        self.i2c_device = I2CDevice(i2c, address)
+        for i in range(10):
+            try:
+                self.buffer = bytearray(8)
+                self.i2c_device = I2CDevice(i2c, address)
+            except ValueError:
+                # boot up delay for third-party controllers
+                time.sleep(1)
+                if i < 10:
+                    continue
+                raise
+            break
         self._i2c_read_delay = i2c_read_delay
         time.sleep(_I2C_INIT_DELAY)
         with self.i2c_device as i2c_dev:

--- a/adafruit_nunchuk.py
+++ b/adafruit_nunchuk.py
@@ -60,17 +60,15 @@ class Nunchuk:
     def __init__(
         self, i2c: I2C, address: int = 0x52, i2c_read_delay: float = 0.002
     ) -> None:
-        for i in range(10):
-            try:
-                self.buffer = bytearray(8)
-                self.i2c_device = I2CDevice(i2c, address)
-            except ValueError:
-                # boot up delay for third-party controllers
-                time.sleep(1)
-                if i < 10:
-                    continue
-                raise
-            break
+        self.buffer = bytearray(8)
+        #-| HACK |---------------------------------------------------
+        # fixes quirk with RP2040 + 3rd party controllers
+        while not i2c.try_lock():
+            pass
+        _ = i2c.scan()
+        i2c.unlock()
+        #------------------------------------------------------------
+        self.i2c_device = I2CDevice(i2c, address)
         self._i2c_read_delay = i2c_read_delay
         time.sleep(_I2C_INIT_DELAY)
         with self.i2c_device as i2c_dev:

--- a/adafruit_nunchuk.py
+++ b/adafruit_nunchuk.py
@@ -61,13 +61,13 @@ class Nunchuk:
         self, i2c: I2C, address: int = 0x52, i2c_read_delay: float = 0.002
     ) -> None:
         self.buffer = bytearray(8)
-        #-| HACK |---------------------------------------------------
+        # -| HACK |---------------------------------------------------
         # fixes quirk with RP2040 + 3rd party controllers
         while not i2c.try_lock():
             pass
         _ = i2c.scan()
         i2c.unlock()
-        #------------------------------------------------------------
+        # ------------------------------------------------------------
         self.i2c_device = I2CDevice(i2c, address)
         self._i2c_read_delay = i2c_read_delay
         time.sleep(_I2C_INIT_DELAY)


### PR DESCRIPTION
hihi- @djecken was using this library with the nunchuk that we sell in the shop and kept getting an error that no device was on 0x52 despite the I2C scan test showing the device. we switched to an official nunchuk and didn't get this error. i ran into this when working on the wii_classic library. third-party controllers seem to take longer to initialize for some reason. i added the same try/except loop here and that has fixed the issue with the nunchuk in the shop.