### PR TITLE
README.rst: Fix install with circup

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,7 @@ following command to install:
 
 .. code-block:: shell
 
-    circup install nunchuk
+    circup install adafruit_nunchuk
 
 Or the following command to update an existing version:
 


### PR DESCRIPTION
Replace `nunchuk` with `adafruit_nunchuk` in command `circup install` to avoid the following issue:

```
Searching for dependencies for: ['nunchuk']
WARNING:
	nunchuk is not a known CircuitPython library.
Ready to install: []
```